### PR TITLE
StepperDriver.h, StepperDriver.c and others

### DIFF
--- a/ESP32_S2_Saola1/include/configGpio.h
+++ b/ESP32_S2_Saola1/include/configGpio.h
@@ -5,8 +5,8 @@
 #include "driverTypes.h"
 #include "espInterrupts.h"
 
-#define STEP_PIN GPIO_NUM_1
-#define STEP_PIN_SEL GPIO_SEL_1
+#define STEP_PIN GPIO_NUM_33
+#define STEP_PIN_SEL GPIO_SEL_33
 
 #define DIR_PIN GPIO_NUM_2
 #define DIR_PIN_SEL GPIO_SEL_2
@@ -14,20 +14,22 @@
 #define EN_PIN GPIO_NUM_0
 #define EN_PIN_SEL GPIO_SEL_0
 
-#define BTN_0_PIN GPIO_NUM_21
-#define BTN_0_PIN_SEL GPIO_SEL_21
-extern volatile bool BTN_0_PIN_STATE;
+#define BTN_0_INPUT_PIN GPIO_NUM_21
+#define BTN_0_INPUT_PIN_SEL GPIO_SEL_21
+extern volatile bool BTN_0_INPUT_PIN_STATE;		// holding in memory is faster for the ISR than re-evaluating GPIO state each time.
 
-#define BTN_0_LED_PIN GPIO_NUM_19
-#define BTN_0_LED_PIN_SEL GPIO_SEL_19
-// if using a transistor or mosfet to switch a higher power source, uncomment the appropriate method.
+#define BTN_0_LED_OUT_PIN GPIO_NUM_19
+#define BTN_0_LED_OUT_PIN_SEL GPIO_SEL_19
+/* 
+	if using a transistor or mosfet to switch a higher power source, uncomment the appropriate method.
+*/
 // #define BTN_0_LED_DRIVER_P
 #define BTN_0_LED_DRIVER_N
 
-#define BTN_1_PIN GPIO_NUM_26
-#define BTN_1_PIN_SEL GPIO_SEL_26
-extern volatile bool BTN_1_PIN_STATE;
+#define BTN_1_INPUT_PIN GPIO_NUM_26
+#define BTN_1_INPUT_PIN_SEL GPIO_SEL_26
+extern volatile bool BTN_1_INPUT_PIN_STATE;
 
-extern void vInitGPIO();
+extern void vInitGpioConfig();
 
 #endif

--- a/ESP32_S2_Saola1/include/configLedc.h
+++ b/ESP32_S2_Saola1/include/configLedc.h
@@ -13,7 +13,7 @@ extern volatile int LEDC_CHANNEL_0_DUTY;
 
 extern int xGetDutyResolutionMax();
 
-extern void vInitLEDC_0( void );
+extern void vInitLedcConfig_0( void );
 
 extern bool getLEDState();
 

--- a/ESP32_S2_Saola1/include/configSteppers.h
+++ b/ESP32_S2_Saola1/include/configSteppers.h
@@ -4,9 +4,9 @@
 #include <StepperDriver.h>
 #include <configGpio.h>
 
-extern volatile StepperHandle_t *stepperMotor_1;
-extern volatile StepperConfig_t *stepperConfig;
+extern StepperHandle_t *StepperMotor_1;
+extern StepperConfig_t *StepperConfig_1;
 
-extern void vInitCurtainStepper();
+extern void vInitCurtainMotorConfig_0();
 
 #endif

--- a/ESP32_S2_Saola1/include/configTimers.h
+++ b/ESP32_S2_Saola1/include/configTimers.h
@@ -7,9 +7,9 @@
 extern timer_config_t config_timer_0;
 extern timer_config_t config_timer_1;
 
-extern void vInitTimer_0();
+extern void vInitTimerConfig_0();
 
-extern void vInitTimer_1();
+extern void vInitTimerConfig_1();
 
 extern void fadeUpdate();
 

--- a/ESP32_S2_Saola1/include/rtosTasks.h
+++ b/ESP32_S2_Saola1/include/rtosTasks.h
@@ -36,7 +36,7 @@ extern void vTaskRotateStepperForward(void * pvPerameters);
 
 extern void vTaskRotateStepperReverse(void * pvPerameters);
 
-extern void vInitTaskCurtainStepper();
+extern void vInitTaskCurtainMotor();
 
 extern void vInitTaskLEDFade( void );
 

--- a/ESP32_S2_Saola1/lib/StepperDriver/StepperDriver.c
+++ b/ESP32_S2_Saola1/lib/StepperDriver/StepperDriver.c
@@ -1,5 +1,5 @@
 #include <StepperDriver.h>
-#include <freertos/FreeRTOS.h>
+#include <assert.h>
 
 /*
  * calculate the step pulse in microseconds for a given rpm value.
@@ -12,11 +12,12 @@
 #define DEFAULT_DECELERATION 1000
 #define MIN_YIELD_MICROS 50
 
-long getStepPulse(long steps, short microsteps, short rpm) {
+inline unsigned getStepPulse(long long steps, short microsteps, short rpm) {
 	return 60.0*1000000L/steps/microsteps/rpm;
 }
 
-void delayMicros(unsigned long delay_us, unsigned long start_us){
+void delayMicros(unsigned delay_us, long long start_us){
+
 	if (delay_us){
 		if (!start_us){
 			start_us = esp_timer_get_time();
@@ -34,28 +35,31 @@ void delayMicros(unsigned long delay_us, unsigned long start_us){
 /*
  * calculate the interval til the next pulse
  */
-void calcStepPulse(StepperHandle_t *stepper_handler){
-    if (stepper_handler->steps_remaining <= 0){  // this should not happen, but avoids strange calculations
+void calcStepPulse(StepperHandle_t *StepperHandle){
+	// validate pointer
+	assert(StepperHandle != NULL);
+
+    if (StepperHandle->steps_remaining <= 0){  // this should not happen, but avoids strange calculations
         return;
     }
-    stepper_handler->steps_remaining--;
-    stepper_handler->step_count++;
+    StepperHandle->steps_remaining--;
+    StepperHandle->step_count++;
 
-    if (stepper_handler->configuration->mode == LINEAR_SPEED){
-        switch (getMotorState(stepper_handler)){
+    if (StepperHandle->Config->mode == LINEAR_SPEED){
+        switch (getMotorState(StepperHandle)){
         case ACCELERATING:
-            if (stepper_handler->step_count < stepper_handler->steps_to_cruise){
-                stepper_handler->step_pulse = stepper_handler->step_pulse - (2*stepper_handler->step_pulse+stepper_handler->rest)/(4*stepper_handler->step_count+1);
-                stepper_handler->rest = (stepper_handler->step_count < stepper_handler->steps_to_cruise) ? (2*stepper_handler->step_pulse+stepper_handler->rest) % (4*stepper_handler->step_count+1) : 0;
+            if (StepperHandle->step_count < StepperHandle->steps_to_cruise){
+                StepperHandle->step_pulse = StepperHandle->step_pulse - (2*StepperHandle->step_pulse+StepperHandle->rest)/(4*StepperHandle->step_count+1);
+                StepperHandle->rest = (StepperHandle->step_count < StepperHandle->steps_to_cruise) ? (2*StepperHandle->step_pulse+StepperHandle->rest) % (4*StepperHandle->step_count+1) : 0;
             } else {
                 // The series approximates target, set the final value to what it should be instead
-                stepper_handler->step_pulse = stepper_handler->cruise_step_pulse;
+                StepperHandle->step_pulse = StepperHandle->cruise_step_pulse;
             }
             break;
 
         case DECELERATING:
-            stepper_handler->step_pulse = stepper_handler->step_pulse - (2*stepper_handler->step_pulse+stepper_handler->rest)/(-4*stepper_handler->steps_remaining+1);
-            stepper_handler->rest = (2*stepper_handler->step_pulse+stepper_handler->rest) % (-4*stepper_handler->steps_remaining+1);
+            StepperHandle->step_pulse = StepperHandle->step_pulse - (2*StepperHandle->step_pulse+StepperHandle->rest)/(-4*StepperHandle->steps_remaining+1);
+            StepperHandle->rest = (2*StepperHandle->step_pulse+StepperHandle->rest) % (-4*StepperHandle->steps_remaining+1);
             break;
 
         default:
@@ -64,104 +68,161 @@ void calcStepPulse(StepperHandle_t *stepper_handler){
     }
 }
 
-StepperHandle_t* createStepperHandler(StepperConfig_t *configuration) {
-	// malloc syntax:
-	// ptr = (cast-type*) malloc(byte-size)
-    StepperHandle_t *new_stepper = (StepperHandle_t*)pvPortMalloc(sizeof(StepperHandle_t));	// allocated dynamically, so it is not terminated when exiting scope.
-	// TODO: Come back here and validate configuration properties.
-    new_stepper->configuration = configuration;
-	new_stepper->motor_state = STOPPED;
-	new_stepper->steps_to_cruise = 0;
-	new_stepper->steps_remaining = 0;
-	new_stepper->steps_to_brake = 0;
-	new_stepper->direction_state = 0;
-	new_stepper->cruise_step_pulse = 0;
-	new_stepper->step_pulse = 0;
-	new_stepper->rest = 0;
-	new_stepper->step_count = 0;
-	new_stepper->step_high_min = 1;
-	new_stepper->step_low_min = 1;
-	new_stepper->wakeup_time = 0;
-	new_stepper->next_action_interval = 0;
-	new_stepper->last_action_end = 0;
-	enableStepper(new_stepper);
-    return new_stepper;
+StepperHandle_t* createStepperHandle(StepperConfig_t *Config) {
+	// validate pointer
+	assert(Config != NULL);
+
+	/*
+		For malloc(), free(), and freeRTOS equivilents see:
+		See https://www.freertos.org/a00111.html
+	*/
+
+#ifdef INC_FREERTOS_H
+	// allocate dynamically so it is not terminated after leaving scope.
+    StepperHandle_t *new_stepper = (StepperHandle_t*)pvPortMalloc(sizeof(StepperHandle_t));	
+#endif
+
+#ifndef INC_FREERTOS_H
+	// allocate dynamically so it is not terminated after leaving scope.
+	StepperHandle_t *NewStepper = (StepperHandle_t*)malloc(sizeof(StepperHandle_t));	// allocated dynamically, so it is not terminated when exiting scope.
+#endif
+
+	// TODO: Come back here and validate Config properties.
+    NewStepper->Config = Config;
+	NewStepper->MotorState = STOPPED;
+	NewStepper->steps_to_cruise = 0;
+	NewStepper->steps_remaining = 0;
+	NewStepper->steps_to_brake = 0;
+	NewStepper->dir_state = 0;
+	NewStepper->cruise_step_pulse = 0;
+	NewStepper->step_pulse = 0;
+	NewStepper->rest = 0;
+	NewStepper->step_count = 0;
+	NewStepper->step_high_min = 1;
+	NewStepper->step_low_min = 1;
+	NewStepper->wakeup_time = 0;
+	NewStepper->pulse_next_time = 0;
+	NewStepper->pulse_end_time = 0;
+	enableStepper(NewStepper);
+    return NewStepper;
 }
 
-StepperMotorState_t getMotorState(StepperHandle_t *StepperHandler) {
+// deallocates memory for a stepper handle with either threadsafe pvPortMalloc() or malloc() depending on the framework used
+void destroyStepperHandle(StepperHandle_t **StepperHandle) {
+	assert(*StepperHandle != NULL);
 
-	if (StepperHandler->steps_remaining <= 0) {
-		StepperHandler->motor_state = STOPPED;
+	/*
+		For malloc(), free(), and freeRTOS equivilents see:
+		See https://www.freertos.org/a00111.html
+	*/
+
+#ifdef INC_FREERTOS_H
+	vPortFree(*StepperHandle)
+#endif
+
+#ifndef INC_FREERTOS_H
+	free(*StepperHandle);
+#endif
+
+	*StepperHandle = NULL;
+
+}
+
+
+StepperMotorState_t getMotorState(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+
+	if (StepperHandle->steps_remaining <= 0) {
+		StepperHandle->MotorState = STOPPED;
 	} else {
-		if (StepperHandler->steps_remaining <= StepperHandler->steps_to_brake) {
-			StepperHandler->motor_state = DECELERATING;
-		} else if (StepperHandler->step_count <= StepperHandler->steps_to_cruise) {
-			StepperHandler->motor_state = ACCELERATING;
+		if (StepperHandle->steps_remaining <= StepperHandle->steps_to_brake) {
+			StepperHandle->MotorState = DECELERATING;
+		} else if (StepperHandle->step_count <= StepperHandle->steps_to_cruise) {
+			StepperHandle->MotorState = ACCELERATING;
 		} else {
-			StepperHandler->motor_state = CRUISING;
+			StepperHandle->MotorState = CRUISING;
 		}
 	}
 
-	return StepperHandler->motor_state;
+	return StepperHandle->MotorState;
 }
 
 /*
  * Configure which logic state on ENABLE pin means active
  * when using SLEEP (default) this is active HIGH
  */
-void setEnableActiveState(StepperHandle_t *StepperHandler, bool state) {
-	StepperHandler->configuration->enable_active_state = state;
+void setEnableActiveState(StepperHandle_t *StepperHandle, bool state) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	StepperHandle->Config->enable_active_state = state;
 }
 
-void disableStepper(StepperHandle_t *StepperHandler) {
+void disableStepper(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
 	// Ensure the pin has been initialized.
-	// if (check_connected(StepperHandler->configuration->enable_pin)) {
+	// if (check_connected(StepperHandle->Config->enable_pin)) {
 		// Set the active state, specified by the user and their hardware.
-		gpio_set_level(StepperHandler->configuration->enable_pin, (StepperHandler->configuration->enable_active_state == HIGH) ? LOW: HIGH);
+		gpio_set_level(StepperHandle->Config->enable_pin, (StepperHandle->Config->enable_active_state == HIGH) ? LOW: HIGH);
 	// }
 }
 
-void enableStepper(StepperHandle_t *StepperHandler) {
+void enableStepper(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
 	// Ensure the pin has been initialized.
-	// if (check_connected(StepperHandler->configuration->enable_pin)) {
+	// if (check_connected(StepperHandle->Config->enable_pin)) {
 		// Set the active state, specified by the user and their hardware.
-		gpio_set_level(StepperHandler->configuration->enable_pin, (StepperHandler->configuration->enable_active_state == HIGH) ? HIGH : LOW);
+		gpio_set_level(StepperHandle->Config->enable_pin, (StepperHandle->Config->enable_active_state == HIGH) ? HIGH : LOW);
 	// }
 }
 
-unsigned getStepperDirection(StepperHandle_t *stepper_handler) {
-	return gpio_get_level(stepper_handler->configuration->direction_pin);
+unsigned getStepperDirection(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	return gpio_get_level(StepperHandle->Config->direction_pin);
 }
 
-void setStepperDirection(StepperHandle_t *stepper_handler, unsigned direction) {
-	stepper_handler->direction_state = direction;
+void setStepperDirection(StepperHandle_t *StepperHandle, short direction) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	StepperHandle->dir_state = direction;
 }
 
-float getStepperRPM(StepperHandle_t *stepper_handler) {
-	return stepper_handler->configuration->rpm;
+float getStepperRPM(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	return StepperHandle->Config->rpm;
 }
 
-void setStepperRPM(StepperHandle_t *stepper_handler, short rpm) {
-	stepper_handler->configuration->rpm = rpm;
+void setStepperRPM(StepperHandle_t *StepperHandle, short rpm) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	StepperHandle->Config->rpm = rpm;
 }
 
-void setMicrosteps(StepperHandle_t *stepper_handler, short microsteps) {
-	stepper_handler->configuration->microstepping = microsteps;
+void setMicrosteps(StepperHandle_t *StepperHandle, short microsteps) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	StepperHandle->Config->microstepping = microsteps;
 }
 
-unsigned getMicrosteps(StepperHandle_t *stepper_handler) {
-	return stepper_handler->configuration->microstepping;
+unsigned getMicrosteps(StepperHandle_t *StepperHandle) {
+	// validate pointer
+	assert(StepperHandle != NULL);
+	return StepperHandle->Config->microstepping;
 }
-
 
 /*
  * Move the motor a given number of steps.
  * positive to move forward, negative to reverse
  */
-void move(StepperHandle_t *stepper_handler, long steps){
-	
-    startMove(stepper_handler, steps, 0);
-    while (nextAction(stepper_handler));
+void move(StepperHandle_t *StepperHandle, long long steps){
+	// validate pointer
+	assert(StepperHandle != NULL);
+    startMove(StepperHandle, steps, 0);
+    while (nextAction(StepperHandle));
 }
 
 /*
@@ -169,90 +230,98 @@ void move(StepperHandle_t *stepper_handler, long steps){
  * Note that using this function even once will add 1K to your program size
  * due to inclusion of float support.
  */
-void rotate(StepperHandle_t *stepper_handler, short deg){
-    move(stepper_handler, calcStepsForRotation(stepper_handler, deg));
+void rotate(StepperHandle_t *StepperHandle, short deg){
+	// validate pointer
+	assert(StepperHandle != NULL);
+	move(StepperHandle, calcStepsForRotation(StepperHandle, deg));
 }
 
 /*
  * Yield to step control
  * Toggle step and return time until next change is needed (micros)
  */
-long nextAction(StepperHandle_t *stepper_handler){
-	if (stepper_handler->steps_remaining > 0){
-        delayMicros(stepper_handler->next_action_interval, stepper_handler->last_action_end);
+unsigned nextAction(StepperHandle_t *StepperHandle){
+	// validate pointer
+	assert(StepperHandle != NULL);
+
+	if (StepperHandle->steps_remaining > 0){
+        delayMicros(StepperHandle->pulse_next_time, StepperHandle->pulse_end_time);
         /*
          * DIR pin is sampled on rising STEP edge, so it is set first
          */
-		gpio_set_level(stepper_handler->configuration->direction_pin, stepper_handler->direction_state);
-		gpio_set_level(stepper_handler->configuration->step_pin, HIGH);
-        unsigned duty_time = esp_timer_get_time();
-        unsigned long pulse = stepper_handler->step_pulse; // save value because calcStepPulse() will overwrite it
-        calcStepPulse(stepper_handler);
+		gpio_set_level(StepperHandle->Config->direction_pin, StepperHandle->dir_state);
+		gpio_set_level(StepperHandle->Config->step_pin, HIGH);
+        long long pulse_start_time = esp_timer_get_time();
+        unsigned pulse = StepperHandle->step_pulse; // save value because calcStepPulse() will overwrite it
+        calcStepPulse(StepperHandle);
         // We should pull HIGH for at least 1-2us (step_high_min)
-        delayMicros(stepper_handler->step_high_min, 0);
-		gpio_set_level(stepper_handler->configuration->step_pin, LOW);
+        delayMicros(StepperHandle->step_high_min, 0);
+		gpio_set_level(StepperHandle->Config->step_pin, LOW);
         // account for calcStepPulse() execution time; sets ceiling for max rpm on slower MCUs
-        stepper_handler->last_action_end = esp_timer_get_time();
-        duty_time = stepper_handler->last_action_end - duty_time;
-		// Actual time it took to execute.
-        stepper_handler->next_action_interval = (pulse > duty_time) ? pulse - duty_time : 1;
+        long long pulse_end_time = esp_timer_get_time();
+		// find executation time duration
+        pulse_start_time = pulse_end_time - pulse_start_time;
+		// determine if we need to wait a number of tics before next pulse, or if we do it as soon as possible (next cycle)
+        StepperHandle->pulse_next_time = (pulse > pulse_start_time) ? pulse - pulse_start_time : 1;
     } else {
         // end of move
-        stepper_handler->last_action_end = 0;
-        stepper_handler->next_action_interval = 0;
+        StepperHandle->pulse_end_time = 0;
+        StepperHandle->pulse_next_time = 0;
     }
-    return stepper_handler->next_action_interval;
+    return StepperHandle->pulse_next_time;
 }
 
 /*
  * Set up a new move (calculate and save the parameters)
  */
-void startMove(StepperHandle_t *stepper_handler, long steps, long time){
-	float speed;
-    // set up new move
-    stepper_handler->direction_state = (steps >= 0) ? HIGH : LOW;
-    stepper_handler->last_action_end = 0;
-    stepper_handler->steps_remaining = labs(steps);
-    stepper_handler->step_count = 0;
-    stepper_handler->rest = 0;
-    switch (stepper_handler->configuration->mode){
+void startMove(StepperHandle_t *StepperHandle, long long steps, unsigned time){
+	// validate pointer
+	assert(StepperHandle != NULL);
+	float lin_speed;
+    // initialize a new move
+    StepperHandle->dir_state = (steps >= 0) ? HIGH : LOW;
+    StepperHandle->pulse_end_time = 0;
+    StepperHandle->steps_remaining = llabs(steps);
+    StepperHandle->step_count = 0;
+    StepperHandle->rest = 0;
+    switch (StepperHandle->Config->mode){
 
 		case LINEAR_SPEED:
 			// speed is in [steps/s]
-			speed = stepper_handler->configuration->rpm * stepper_handler->configuration->motor_steps / 60;
+			lin_speed = StepperHandle->Config->rpm * StepperHandle->Config->motor_steps / 60;
 			if (time > 0){
 				// Calculate a new speed to finish in the time requested
 				float t = time / (1e+6);                  // convert to seconds
-				float d = stepper_handler->steps_remaining / stepper_handler->configuration->microstepping;   // convert to full steps
+				float d = StepperHandle->steps_remaining / StepperHandle->Config->microstepping;   // convert to full steps
 				float a2 = 1.0 / DEFAULT_ACCELERATION + 1.0 / DEFAULT_DECELERATION;
 				float sqrt_candidate = t*t - 2 * a2 * d;  // in √b^2-4ac
 				if (sqrt_candidate >= 0){
-					speed = fmin(speed, (t - (float)sqrt(sqrt_candidate)) / a2);
+					lin_speed = fmin(lin_speed, (t - (float)sqrt(sqrt_candidate)) / a2);
 				};
 			}
 			// how many microsteps from 0 to target speed
-			stepper_handler->steps_to_cruise = stepper_handler->configuration->microstepping * (speed * speed / (2 * DEFAULT_ACCELERATION));
+			StepperHandle->steps_to_cruise = StepperHandle->Config->microstepping * (lin_speed * lin_speed / (2 * DEFAULT_ACCELERATION));
 			// how many microsteps are needed from cruise speed to a full stop
-			stepper_handler->steps_to_brake = stepper_handler->steps_to_cruise * DEFAULT_ACCELERATION / DEFAULT_DECELERATION;
-			if (stepper_handler->steps_remaining < stepper_handler->steps_to_cruise + stepper_handler->steps_to_brake){
+			StepperHandle->steps_to_brake = StepperHandle->steps_to_cruise * DEFAULT_ACCELERATION / DEFAULT_DECELERATION;
+			if (StepperHandle->steps_remaining < StepperHandle->steps_to_cruise + StepperHandle->steps_to_brake){
 				// cannot reach max speed, will need to brake early
-				stepper_handler->steps_to_cruise = stepper_handler->steps_remaining * DEFAULT_DECELERATION / (DEFAULT_ACCELERATION + DEFAULT_DECELERATION);
-				stepper_handler->steps_to_brake = stepper_handler->steps_remaining - stepper_handler->steps_to_cruise;
+				StepperHandle->steps_to_cruise = StepperHandle->steps_remaining * DEFAULT_DECELERATION / (DEFAULT_ACCELERATION + DEFAULT_DECELERATION);
+				StepperHandle->steps_to_brake = StepperHandle->steps_remaining - StepperHandle->steps_to_cruise;
 			}
 			// Initial pulse (c0) including error correction factor 0.676 [us]
-			stepper_handler->step_pulse = (1e+6)*0.676*sqrt(2.0f/DEFAULT_ACCELERATION/stepper_handler->configuration->microstepping);
+			StepperHandle->step_pulse = (1e+6)*0.676*sqrt(2.0f/DEFAULT_ACCELERATION/StepperHandle->Config->microstepping);
 			// Save cruise timing since we will no longer have the calculated target speed later
-			stepper_handler->cruise_step_pulse = 1e+6 / speed / stepper_handler->configuration->microstepping;
+			StepperHandle->cruise_step_pulse = 1e+6 / lin_speed / StepperHandle->Config->microstepping;
 			break;
 
 		case CONSTANT_SPEED:
 		default:
-			stepper_handler->steps_to_cruise = 0;
-			stepper_handler->steps_to_brake = 0;
-			stepper_handler->step_pulse = stepper_handler->cruise_step_pulse = getStepPulse(stepper_handler->configuration->motor_steps, stepper_handler->configuration->microstepping, stepper_handler->configuration->rpm);
+			StepperHandle->steps_to_cruise = 0;
+			StepperHandle->steps_to_brake = 0;
+			StepperHandle->step_pulse = StepperHandle->cruise_step_pulse = getStepPulse(StepperHandle->Config->motor_steps, StepperHandle->Config->microstepping, StepperHandle->Config->rpm);
 
-			if (time > stepper_handler->steps_remaining * stepper_handler->step_pulse){
-				stepper_handler->step_pulse = time / stepper_handler->steps_remaining;
+			if (time > StepperHandle->steps_remaining * StepperHandle->step_pulse){
+				StepperHandle->step_pulse = time / StepperHandle->steps_remaining;
 			}
 
 		}
@@ -262,21 +331,26 @@ void startMove(StepperHandle_t *stepper_handler, long steps, long time){
  * Move the motor an integer number of degrees (360 = full rotation)
  * This has poor precision for small amounts, since step is usually 1.8deg
  */
-void startRotate(StepperHandle_t *stepper_handler, short deg){
-    startMove(stepper_handler, calcStepsForRotation(stepper_handler, deg), 0L);
+inline void startRotate(StepperHandle_t *StepperHandle, short deg){
+	// validate pointer
+	assert(StepperHandle != NULL);
+    startMove(StepperHandle, calcStepsForRotation(StepperHandle, deg), 0L);
 }
 
 /*
  * Brake early.
  */
-void startBrake(StepperHandle_t *stepper_handler){
-    switch (getMotorState(stepper_handler)){
+void startBrake(StepperHandle_t *StepperHandle){
+	// validate pointer
+	assert(StepperHandle != NULL);
+
+    switch (getMotorState(StepperHandle)){
     case CRUISING:  // this applies to both CONSTANT_SPEED and LINEAR_SPEED modes
-        stepper_handler->steps_remaining = stepper_handler->steps_to_brake;
+        StepperHandle->steps_remaining = StepperHandle->steps_to_brake;
         break;
 
     case ACCELERATING:
-        stepper_handler->steps_remaining = stepper_handler->step_count * DEFAULT_ACCELERATION / DEFAULT_DECELERATION;
+        StepperHandle->steps_remaining = StepperHandle->step_count * DEFAULT_ACCELERATION / DEFAULT_DECELERATION;
         break;
 
     default:
@@ -287,39 +361,45 @@ void startBrake(StepperHandle_t *stepper_handler){
 /*
  * Stop movement immediately and return remaining steps.
  */
-long stop(StepperHandle_t *stepper_handler){
-    long retval = stepper_handler->steps_remaining;
-    stepper_handler->steps_remaining = 0;
-    return retval;
+long long stop(StepperHandle_t *StepperHandle){
+	// validate pointer
+	assert(StepperHandle != NULL);
+    long long v = StepperHandle->steps_remaining;
+    StepperHandle->steps_remaining = 0;
+    return v;
 }
 
 /*
- * Return calculated time to complete the given move
+ * Return calculated time to complete the given number of steps (in microseconds)
  */
-long getTimeForMove(StepperHandle_t *stepper_handler, long steps){
+unsigned getTimeForMove(StepperHandle_t *StepperHandle, long long steps){
     float t;
-    long cruise_steps;
-    float speed;
+	float speed;
+    unsigned cruise_steps;
+    
     if (steps == 0){
         return 0;
     }
-    switch (stepper_handler->configuration->mode){
+    switch (StepperHandle->Config->mode){
         case LINEAR_SPEED:
-            startMove(stepper_handler, steps, 0L);
-            cruise_steps = stepper_handler->steps_remaining - stepper_handler->steps_to_cruise - stepper_handler->steps_to_brake;
-            speed = stepper_handler->configuration->rpm * stepper_handler->configuration->motor_steps / 60;   // full steps/s
-            t = (cruise_steps / (stepper_handler->configuration->microstepping * speed)) + 
-                sqrt(2.0 * stepper_handler->steps_to_cruise / DEFAULT_ACCELERATION / stepper_handler->configuration->microstepping) +
-                sqrt(2.0 * stepper_handler->steps_to_brake / DEFAULT_DECELERATION / stepper_handler->configuration->microstepping);
+            startMove(StepperHandle, steps, 0L);
+            cruise_steps = StepperHandle->steps_remaining - StepperHandle->steps_to_cruise - StepperHandle->steps_to_brake;
+            speed = StepperHandle->Config->rpm * StepperHandle->Config->motor_steps / 60;   // full steps/s
+            t = (cruise_steps / (StepperHandle->Config->microstepping * speed)) + 
+                sqrt(2.0 * StepperHandle->steps_to_cruise / DEFAULT_ACCELERATION / StepperHandle->Config->microstepping) +
+                sqrt(2.0 * StepperHandle->steps_to_brake / DEFAULT_DECELERATION / StepperHandle->Config->microstepping);
             t *= (1e+6); // seconds -> micros
             break;
         case CONSTANT_SPEED:
         default:
-			t = steps * getStepPulse(stepper_handler->configuration->motor_steps, stepper_handler->configuration->microstepping, stepper_handler->configuration->rpm);
+			t = steps * getStepPulse(StepperHandle->Config->motor_steps, StepperHandle->Config->microstepping, StepperHandle->Config->rpm);
     }
     return round(t);
 }
 
-long calcStepsForRotation(StepperHandle_t *stepper_handler, short deg){
-	return deg * stepper_handler->configuration->motor_steps * stepper_handler->configuration->microstepping / 360;
+inline long long calcStepsForRotation(StepperHandle_t *StepperHandle, short deg){
+	// validate pointer
+	assert(StepperHandle != NULL);
+	// use 64 width in case of large movements
+	return deg * StepperHandle->Config->motor_steps * StepperHandle->Config->microstepping / 360;
 }

--- a/ESP32_S2_Saola1/src/configGpio.c
+++ b/ESP32_S2_Saola1/src/configGpio.c
@@ -1,6 +1,6 @@
 #include <configGpio.h>
 
-inline void vInitGPIO(){ 
+void vInitGpioConfig(){ 
 	// Configure all GPIO here.
 	// Note: avoid designated initializers since they do not play friendly with C++ syntax & compiler
 	gpio_config_t STEP_CONF;
@@ -25,14 +25,14 @@ inline void vInitGPIO(){
 	EN_CONF.intr_type = GPIO_INTR_DISABLE;
 
 	gpio_config_t BTN_0_CONF;
-	BTN_0_CONF.pin_bit_mask = BTN_0_PIN_SEL;
+	BTN_0_CONF.pin_bit_mask = BTN_0_INPUT_PIN_SEL;
 	BTN_0_CONF.mode = GPIO_MODE_INPUT;
 	BTN_0_CONF.pull_up_en = GPIO_PULLUP_DISABLE;
 	BTN_0_CONF.pull_down_en = GPIO_PULLDOWN_ENABLE;
 	BTN_0_CONF.intr_type = GPIO_INTR_DISABLE;
 	
 	gpio_config_t BTN_0_LED_CONF;
-	BTN_0_LED_CONF.pin_bit_mask = BTN_0_LED_PIN_SEL;
+	BTN_0_LED_CONF.pin_bit_mask = BTN_0_LED_OUT_PIN_SEL;
 	BTN_0_LED_CONF.mode = GPIO_MODE_OUTPUT;
 #ifdef BTN_0_LED_DRIVER_P
 	BTN_0_LED_CONF.pull_up_en = GPIO_PULLUP_ENABLE;
@@ -46,10 +46,10 @@ inline void vInitGPIO(){
 
 	// TODO: Solve how to do a boolean GPIO Interrupt without cuasing kernal panic loop
 	// gpio_install_isr_service(ESP_INTR_FLAG_EDGE);
-	// gpio_isr_handler_add(BTN_0_PIN, xISR_button_0, 0);
+	// gpio_isr_handler_add(BTN_0_INPUT_PIN, xISR_button_0, 0);
 
 	gpio_config_t BTN_1_CONF;
-	BTN_1_CONF.pin_bit_mask = BTN_1_PIN_SEL;
+	BTN_1_CONF.pin_bit_mask = BTN_1_INPUT_PIN_SEL;
 	BTN_1_CONF.mode = GPIO_MODE_INPUT;
 	BTN_1_CONF.pull_up_en = GPIO_PULLUP_DISABLE;
 	BTN_1_CONF.pull_down_en = GPIO_PULLDOWN_ENABLE;

--- a/ESP32_S2_Saola1/src/configLedc.c
+++ b/ESP32_S2_Saola1/src/configLedc.c
@@ -6,7 +6,7 @@ inline int xGetDutyResolutionMax() {
 	return (pow(2, LEDC_CHANNEL_0_DUTY_BITS) - 1);
 }
 
-inline void vInitLEDC_0( void ) {
+void vInitLedcConfig_0( void ) {
 	// config ledc peripherials and channels here.
 	// Note: when needing to reference a channel, use the appropriate C macros instead of the direct objects.
 	ledc_timer_config_t ledc_timer_conf_0;
@@ -17,7 +17,7 @@ inline void vInitLEDC_0( void ) {
 	ledc_timer_conf_0.duty_resolution = LEDC_CHANNEL_0_DUTY_BITS;
 
 	ledc_channel_config_t ledc_channel_conf_0;
-	ledc_channel_conf_0.gpio_num = BTN_0_LED_PIN;
+	ledc_channel_conf_0.gpio_num = BTN_0_LED_OUT_PIN;
 	ledc_channel_conf_0.speed_mode = LEDC_LOW_SPEED_MODE;
 	ledc_channel_conf_0.timer_sel = LEDC_TIMER_0;
 	ledc_channel_conf_0.duty = LEDC_CHANNEL_0_DUTY;

--- a/ESP32_S2_Saola1/src/configSteppers.c
+++ b/ESP32_S2_Saola1/src/configSteppers.c
@@ -1,19 +1,19 @@
 #include <configSteppers.h>
 
-volatile StepperConfig_t *stepperConfig = NULL;
-volatile StepperHandle_t *stepperMotor_1 = NULL;
+StepperConfig_t *StepperConfig_1 = NULL;
+StepperHandle_t *StepperMotor_1 = NULL;
 
-inline void vInitCurtainStepper() {
-	stepperConfig = (StepperConfig_t*)malloc(sizeof(StepperConfig_t));
+void vInitCurtainMotorConfig_0() {
+	StepperConfig_1 = (StepperConfig_t*)malloc(sizeof(StepperConfig_t));
 
-	stepperConfig->step_pin = STEP_PIN;
-	stepperConfig->direction_pin = DIR_PIN;
-	stepperConfig->enable_pin = EN_PIN;
-	stepperConfig->enable_active_state = 1;
-	stepperConfig->motor_steps = 200;
-	stepperConfig->rpm = 200;
-	stepperConfig->microstepping = 64;
-	stepperConfig->mode = CONSTANT_SPEED;
+	StepperConfig_1->step_pin = STEP_PIN;
+	StepperConfig_1->direction_pin = DIR_PIN;
+	StepperConfig_1->enable_pin = EN_PIN;
+	StepperConfig_1->enable_active_state = 1;
+	StepperConfig_1->motor_steps = 200;
+	StepperConfig_1->rpm = 200;
+	StepperConfig_1->microstepping = 64;
+	StepperConfig_1->mode = CONSTANT_SPEED;
 
-	stepperMotor_1 = createStepperHandler(stepperConfig);
+	StepperMotor_1 = createStepperHandle(StepperConfig_1);
 }

--- a/ESP32_S2_Saola1/src/configTimers.c
+++ b/ESP32_S2_Saola1/src/configTimers.c
@@ -3,7 +3,7 @@
 timer_config_t config_timer_0;
 timer_config_t config_timer_1;
 
-inline void vSetLEDFadePeriod(int ms) {
+void vSetLEDFadePeriod(int ms) {
 
 	int timer_0_frequency = APB_CLK_FREQ/config_timer_0.divider;
 	int period_ms = timer_0_frequency/1000;
@@ -18,7 +18,7 @@ inline void vSetLEDFadePeriod(int ms) {
 	timer_start(TIMER_GROUP_0, TIMER_0);
 }
 
-inline void vInitTimer_0() {
+void vInitTimerConfig_0() {
 	// Note: do not use C designated initializers as they are not friendly with C++ syntax.
 	config_timer_0.clk_src = TIMER_SRC_CLK_APB;
 	config_timer_0.divider = 2;					 // 40hz
@@ -39,7 +39,7 @@ inline void vInitTimer_0() {
 	timer_start(TIMER_GROUP_0, TIMER_0);
 } 
 
-inline void vInitTimer_1() {
+void vInitTimerConfig_1() {
 	// Note: do not use C designated initializers as they are not friendly with C++ syntax.
 	timer_config_t config_timer_1;
 	config_timer_1.clk_src = TIMER_SRC_CLK_APB;

--- a/ESP32_S2_Saola1/src/espInterrupts.c
+++ b/ESP32_S2_Saola1/src/espInterrupts.c
@@ -12,8 +12,8 @@ volatile bool BTN_1_PIN_STATE;
 
 void updateButtonsState() {
 	// do this once every interrupt, as to avoid checking the pin logic multiple times.
-	BTN_0_PIN_STATE = gpio_get_level(BTN_0_PIN);
-	BTN_1_PIN_STATE = gpio_get_level(BTN_1_PIN);
+	BTN_0_PIN_STATE = gpio_get_level(BTN_0_INPUT_PIN);
+	BTN_1_PIN_STATE = gpio_get_level(BTN_1_INPUT_PIN);
 }
 
 // All interrupts must be declared as a boolean to signify if they yield or not.
@@ -50,7 +50,7 @@ extern inline bool IRAM_ATTR xISR_button_0(void * args) {
 		// Check if any prioritized tasks are running.
 		if (eTaskGetState(xHandleCloseCurtains) != eRunning) {
 			// Immediate stop stepper from running tasks.
-			stop(stepperMotor_1);	
+			stop(StepperMotor_1);	
 		}
 
 		// See if LED is on/off

--- a/ESP32_S2_Saola1/src/main.cpp
+++ b/ESP32_S2_Saola1/src/main.cpp
@@ -1,12 +1,12 @@
 /*
 	Include C++ headers here.
 
-	If you want to use C++ libraries, they must be included in this CPP OR explicitely wrapped as extern "C++" {} so the compiler knows what conventions to use
-	and how to link them.
+	If you use C++ libraries, they should be included in this CPP scope OR explicitely wrapped as extern "C++" {} so the compiler knows what conventions to use
+	and how to link them together.
 */
 
 /*
-	Tell the compiler to wrap main as C convention since most of the IDF framework in standard C.
+	Tell the compiler to wrap main for C convention since most of the IDF framework in standard C but we may want to use C++ occasionally.
 */
 
 extern "C" {
@@ -19,50 +19,42 @@ extern "C" {
 	#include <configTimers.h>
 	#include <configSteppers.h>
 	#include <esp_timer.h>
+	#include <freeRTOS/FreeRTOS.h>
 
     void app_main(void);
 }
 
 void app_main(void) {
-	// Call all initializers first.
 
-	// NOTE: For debugging the stepper driver issue, disable all other microcontroller features/tasks
-	//		 except for what is required (like initializing output pins).
+	// initialize peripherials and resources here.
+	vInitGpioConfig();					// GPIO pin configuration
+	vInitLedcConfig_0();				// LED PWM generator
+	vInitTimerConfig_0();				// Button interrupts
+	vInitCurtainMotorConfig_0();
 
-	// vInitTaskRTOSDebug();
-	vInitGPIO();
-	// vInitLEDC_0();
-	// vInitTaskLEDFade();
-	// vInitCurtainStepper();
-	// vInitTaskCurtainStepper();
-	// vInitTaskCloseCurtains();
-	// vInitTimer_0();	// starts button interrupts.
+	// initialize RTOS tasks here
+	vInitTaskLEDFade();					// Task to fade the LED buttons
+	vInitTaskCurtainMotor();			// Multiple Tasks to control the stepper motor
+
+
+
+
+
+
+
+
+
 	// xTaskNotify(xHandleCloseCurtains, 1, eSetValueWithOverwrite);
 
-	// Allocated and create a pointer to a stepper config struct.
-	StepperConfig_t *sc = (StepperConfig_t*)pvPortMalloc(sizeof(StepperConfig_t));
-	// set the used pins and the settings for the motor.
-	sc->step_pin = STEP_PIN;
-	sc->direction_pin = DIR_PIN;
-	sc->enable_pin = EN_PIN;
-	sc->enable_active_state = 1;
-	sc->motor_steps = 200;
-	sc->rpm = 200;
-	sc->microstepping = 64;
-	sc->mode = CONSTANT_SPEED;
+	// // rotate the motor 360 degrees then wait for 3 seconds.
+	// while (1) {
+	// 	rotate(StepperMotor_1, 360);
+	// 	vTaskDelay(pdMS_TO_TICKS(3 * 1000));
+	// }
 
-	// pass the configuration to the create handle method. returns a pointer to a handle type.
-	StepperHandle_t *stepper = createStepperHandler(sc);
-
-	// rotate the motor 360 degrees then wait for 3 seconds.
-	while (1) {
-		rotate(stepper, 360);
-		vTaskDelay(pdMS_TO_TICKS(3 * 1000));
-		// ignore this. the below task can print Task information such as stack size etc but revealed anything useful.
-		// xTaskNotify(xHandleRTOSDebug, 1, eSetValueWithOverwrite);
-		printf("heap_caps_get_free_size: %u\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
-		printf("xPortGetFreeHeapSize: %u\n\n", xPortGetFreeHeapSize());
-	}
+	// xTaskNotify(xHandleRTOSDebug, 1, eSetValueWithOverwrite);
+	// printf("heap_caps_get_free_size: %u\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
+	// printf("xPortGetFreeHeapSize: %u\n\n", xPortGetFreeHeapSize());
 
 }
 


### PR DESCRIPTION
Refactored StepperDriver library to use 64 bit integers for esp_get_time() compatability.

Added preprocessor checks to call the appropriate malloc or pvPortMalloc methods.

Changed naming conventions so all instantiated structs are CamelCase

Organized main to initialize resources first then RTOS tasks.

Bundled some RTOS task initializers together for the primary stepper motor to reduce calls and API overhead